### PR TITLE
Reduced Rank KS-eigenvalue Problem for Linear Dependent Basis Functions

### DIFF
--- a/embasi/roothan_hall_eigensolver.py
+++ b/embasi/roothan_hall_eigensolver.py
@@ -9,6 +9,8 @@ def invsqr_overlap_calc(overlap):
 
 def xform_hamiltonian(hamiltonian, xform_mat):
 
+    from embasi.parallel_utils import root_print
+
     return xform_mat.T @ hamiltonian @ xform_mat
 
 def back_xform_evecs(eigenvectors, xform_mat):
@@ -38,9 +40,40 @@ def calculate_densmat(eigenvectors, occ_mat):
 
     return occ_evecs @ occ_evecs.T
 
+def overlap_illcondition_check(overlap, thresh):
+
+    from scipy.linalg import eig_banded, eigh
+
+    n_basis = np.shape(overlap)[0]
+
+    ovlp_evals, ovlp_evecs = eigh(overlap, subset_by_value=[thresh,10000.])
+    
+    # Count non-singular values
+    n_good = np.size(ovlp_evals)
+    n_bad = np.shape(overlap)[0] - n_good
+
+    if n_bad > 0:
+        # Transform overlap matrix
+        ovlp_filtered = ovlp_evecs
+
+        for idx in np.arange(n_good):
+            sqrt_ev = np.sqrt(ovlp_evals[idx])
+            ovlp_filtered[:, idx] = ovlp_filtered[:, idx]/sqrt_ev
+
+    else:
+        sigma_sqrt = np.diag(ovlp_evals**(-0.5))
+        ovlp_filtered = ovlp_evecs @ sigma_sqrt @ ovlp_evecs.T
+
+    return ovlp_filtered, n_bad
+
 def hamiltonian_eigensolv(hamiltonian, overlap, nelec):
 
-    xform_mat = invsqr_overlap_calc(overlap)
+    from embasi.parallel_utils import root_print
+
+    thresh = 1e-5
+    n_basis = np.shape(overlap)[0]
+    xform_mat, n_bad = overlap_illcondition_check(overlap, thresh)
+    n_good = n_basis - n_bad
 
     evals, evecs = np.linalg.eig(xform_hamiltonian(hamiltonian, xform_mat))
     evecs = back_xform_evecs(evecs, xform_mat)


### PR DESCRIPTION
Resolves Issue #4. Solve reduced rank KS eigenvalue problem to remove basis functions with linear dependence on other basis functions. Uses same basis threshold threshold as FHI-aims. 
